### PR TITLE
WIP: Add support to act as pip plugin

### DIFF
--- a/pipdeptree.py
+++ b/pipdeptree.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 import argparse
 
 import pip
+from pip.basecommand import Command
 
 
 flatten = chain.from_iterable
@@ -205,7 +206,38 @@ def peek_into(iterator):
     return is_empty, b
 
 
-def main():
+class DepTreePipCommand(Command):
+    name = 'deptree'
+    usage = """
+      %prog [options]"""
+    summary = 'Display a dependency tree of the installed python packages'
+
+    def __init__(self, *args, **kw):
+        super(DepTreePipCommand, self).__init__(*args, **kw)
+
+        cmd_opts = self.cmd_opts
+        parser = get_parser()
+
+        for action in parser._actions:
+            if '--help' in action.option_strings:
+                continue
+            add_option_kwargs = {}
+            for key in ('dest', 'nargs', 'default', 'type',
+                        'choices', 'help', 'metavar'):
+                add_option_kwargs[key] = getattr(action, key)
+            if action.const is True:
+                add_option_kwargs['action'] = 'store_const'
+                add_option_kwargs['const'] = action.const
+                del add_option_kwargs['nargs']
+            cmd_opts.add_option(*action.option_strings, **add_option_kwargs)
+
+        self.parser.insert_option_group(0, cmd_opts)
+
+    def run(self, options, args):
+        do_deptree(args=options)
+
+
+def get_parser():
     parser = argparse.ArgumentParser(description=(
         'Dependency tree of the installed python packages'
     ))
@@ -223,8 +255,16 @@ def main():
                             'Inhibit warnings about possibly '
                             'confusing packages'
                         ))
-    args = parser.parse_args()
+    return parser
 
+
+def main():
+    parser = get_parser()
+    args = parser.parse_args()
+    do_deptree(args)
+
+
+def do_deptree(args):
     default_skip = ['setuptools', 'pip', 'python', 'distribute']
     skip = default_skip + ['pipdeptree']
     pkgs = pip.get_installed_distributions(local_only=args.local_only,

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,9 @@ setup(
     install_requires=install_requires,
     py_modules=['pipdeptree'],
     entry_points={
+        'pip.command.v1': [
+            'deptree = pipdeptree:DepTreePipCommand',
+        ],
         'console_scripts': [
             'pipdeptree = pipdeptree:main'
         ]


### PR DESCRIPTION
This is an experimental feature to make pipdeptree into a **pip plugin**, which is a new concept that I proposed in https://github.com/pypa/pip/pull/2329

```
[marca@marca-mac2 ~WORKON_HOME]$ mktmpenv
New python executable in tmp-4adc64ecf8c6ac9e/bin/python
Please make sure you remove any previous custom paths from your /Users/marca/.pydistutils.cfg file.
Installing setuptools, pip...done.
This is a temporary environment. It will be deleted when you run 'deactivate'.

[marca@marca-mac2 ~VIRTUAL_ENV]$ pip install https://github.com/msabramo/pip/archive/command_plugins.zip
...
Successfully installed pip-6.1.0.dev0

# Install the pipdeptree plugin
[marca@marca-mac2 ~VIRTUAL_ENV]$ pip install https://github.com/msabramo/pipdeptree/archive/pip_plugin.zip
Collecting https://github.com/msabramo/pipdeptree/archive/pip_plugin.zip
  Downloading https://github.com/msabramo/pipdeptree/archive/pip_plugin.zip
     - 20kB 85kB/s
Requirement already satisfied (use --upgrade to upgrade): pip>=1.4.1 in ./lib/python2.7/site-packages (from pipdeptree==0.4.2)
Installing collected packages: pipdeptree
  Running setup.py install for pipdeptree
    Installing pipdeptree script to /Users/marca/python/virtualenvs/tmp-4adc64ecf8c6ac9e/bin
Successfully installed pipdeptree-0.4.2

[marca@marca-mac2 ~VIRTUAL_ENV]$ pip

Usage:
  pip <command> [options]

Commands:
  ...
  deptree                     Display a dependency tree of the installed python packages

[marca@marca-mac2 ~VIRTUAL_ENV]$ pip deptree --help

Usage:
  pip deptree [options]

Deptree Options:
  -f, --freeze                Print names so as to write freeze files
  -a, --all                   list all deps at top level
  -l, --local-only            If in a virtualenv that has global access donot show globally installed packages
  -w, --nowarn                Inhibit warnings about possibly confusing packages
...

# Just installing a few packages so that the output of `pip deptree` is more interesting...
[marca@marca-mac2 ~VIRTUAL_ENV]$ pip install flask ipython
...

[marca@marca-mac2 ~VIRTUAL_ENV]$ pip deptree
wsgiref==0.1.2
Flask==0.10.1
  - Werkzeug [required: >=0.7, installed: 0.9.6]
  - Jinja2 [required: >=2.4, installed: 2.7.3]
    - MarkupSafe [installed: 0.23]
  - itsdangerous [required: >=0.21, installed: 0.24]
ipython==2.3.1
  - gnureadline [installed: 6.3.3]
wheel==0.24.0
```

Cc: @naiquevin, @therealprologic

Refs: https://github.com/naiquevin/pipdeptree/issues/1
