### PR TITLE
Show warning for unsatisfied/missing dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,14 @@ clean:
 	find . -name '*.pyc' -exec rm -f {} +
 	find . -name '*.pyo' -exec rm -f {} +
 	find . -name '*~' -exec rm -f {} +
+	find . -name '__pycache__' -exec rmdir {} +
 
 clean-env:
-	rm -rf tests/virtualenvs/{testenv,cyclicenv}
+	rm -rf tests/virtualenvs/{testenv,cyclicenv,unsatisfiedenv}
 	rm tests/virtualenvs/*.pickle
 
 test-env:
-	cd tests/virtualenvs; make testenv cyclicenv
+	cd tests/virtualenvs; make testenv cyclicenv unsatisfiedenv
 
 test: test-env
 	tox -e py27

--- a/pipdeptree.py
+++ b/pipdeptree.py
@@ -391,7 +391,7 @@ def main():
             print('Warning!!! Possibly conflicting dependencies found:', file=sys.stderr)
             for p, reqs in conflicting.items():
                 pkg = p.render_as_root(False)
-                print('* %s' % pkg)
+                print('* %s' % pkg, file=sys.stderr)
                 for req in reqs:
                     if not req.dist:
                         req_str = ('{0} [required: {1}, '

--- a/pipdeptree.py
+++ b/pipdeptree.py
@@ -396,6 +396,7 @@ def main():
     skip = default_skip + ['pipdeptree']
     pkgs = pip.get_installed_distributions(local_only=args.local_only,
                                            skip=skip)
+
     dist_index = build_dist_index(pkgs)
     tree = construct_tree(dist_index)
 

--- a/tests/test_pipdeptree.py
+++ b/tests/test_pipdeptree.py
@@ -2,7 +2,7 @@ import pickle
 
 from pipdeptree import (build_dist_index, construct_tree, peek_into,
                         DistPackage, ReqPackage, render_tree,
-                        reverse_tree, unsatisfied_deps)
+                        reverse_tree, conflicting_deps)
 
 
 def venv_fixture(pickle_file):
@@ -159,19 +159,19 @@ def test_peek_into():
     assert len(list(g2)) == 100
 
 
-def test_unsatisfied_deps():
+def test_conflicting_deps():
     # the custom environment has a bad jinja version and it's missing simplejson
-    _, _, unsatisfied_tree = venv_fixture('tests/virtualenvs/unsatisfiedenv.pickle')
-    flask = next((x for x in unsatisfied_tree.keys() if x.key == 'flask'))
-    jinja = next((x for x in unsatisfied_tree[flask] if x.key == 'jinja2'))
-    uritemplate = next((x for x in unsatisfied_tree.keys() if x.key == 'uritemplate'))
-    simplejson = next((x for x in unsatisfied_tree[uritemplate] if x.key == 'simplejson'))
+    _, _, conflicting_tree = venv_fixture('tests/virtualenvs/unsatisfiedenv.pickle')
+    flask = next((x for x in conflicting_tree.keys() if x.key == 'flask'))
+    jinja = next((x for x in conflicting_tree[flask] if x.key == 'jinja2'))
+    uritemplate = next((x for x in conflicting_tree.keys() if x.key == 'uritemplate'))
+    simplejson = next((x for x in conflicting_tree[uritemplate] if x.key == 'simplejson'))
     assert jinja
     assert flask
     assert uritemplate
     assert simplejson
 
-    unsatisfied = unsatisfied_deps(unsatisfied_tree)
+    unsatisfied = conflicting_deps(conflicting_tree)
     assert unsatisfied == {
         flask: [jinja],
         uritemplate: [simplejson],

--- a/tests/test_pipdeptree.py
+++ b/tests/test_pipdeptree.py
@@ -2,7 +2,7 @@ import pickle
 
 from pipdeptree import (build_dist_index, construct_tree, peek_into,
                         DistPackage, ReqPackage, render_tree,
-                        reverse_tree)
+                        reverse_tree, unsatisfied_deps)
 
 
 def venv_fixture(pickle_file):
@@ -157,3 +157,22 @@ def test_peek_into():
     r2, g2 = peek_into(i for i in range(100))
     assert not r2
     assert len(list(g2)) == 100
+
+
+def test_unsatisfied_deps():
+    # the custom environment has a bad jinja version and it's missing simplejson
+    _, _, unsatisfied_tree = venv_fixture('tests/virtualenvs/unsatisfiedenv.pickle')
+    flask = next((x for x in unsatisfied_tree.keys() if x.key == 'flask'))
+    jinja = next((x for x in unsatisfied_tree[flask] if x.key == 'jinja2'))
+    uritemplate = next((x for x in unsatisfied_tree.keys() if x.key == 'uritemplate'))
+    simplejson = next((x for x in unsatisfied_tree[uritemplate] if x.key == 'simplejson'))
+    assert jinja
+    assert flask
+    assert uritemplate
+    assert simplejson
+
+    unsatisfied = unsatisfied_deps(unsatisfied_tree)
+    assert unsatisfied == {
+        flask: [jinja],
+        uritemplate: [simplejson],
+    }

--- a/tests/virtualenvs/.gitignore
+++ b/tests/virtualenvs/.gitignore
@@ -1,3 +1,4 @@
 *.pickle
 testenv/
 cyclicenv/
+unsatisfiedenv/

--- a/tests/virtualenvs/Makefile
+++ b/tests/virtualenvs/Makefile
@@ -12,3 +12,11 @@ cyclicenv:
 	cyclicenv/bin/pip install -U pip setuptools
 	cyclicenv/bin/pip install -r cyclicenv_requirements.txt
 	cyclicenv/bin/python pickle_env.py > cyclicenv.pickle
+
+unsatisfiedenv:
+	virtualenv unsatisfiedenv
+	unsatisfiedenv/bin/pip install -U pip setuptools
+	unsatisfiedenv/bin/pip install -r unsatisfiedenv_requirements.txt
+	# test case where simplejson is required but not installed
+	unsatisfiedenv/bin/pip install uritemplate==0.6 --no-dependencies
+	unsatisfiedenv/bin/python pickle_env.py > unsatisfiedenv.pickle

--- a/tests/virtualenvs/unsatisfiedenv_requirements.txt
+++ b/tests/virtualenvs/unsatisfiedenv_requirements.txt
@@ -1,0 +1,6 @@
+Flask==0.10.1
+itsdangerous==0.24
+Jinja2==2.3 # requires >=2.4
+MarkupSafe==0.23
+Werkzeug==0.11.2
+argparse


### PR DESCRIPTION
I took a crack at #20 (using pkg_resources.parse_version to warn about unsatisfied or missing dependencies). It works pretty well on all the virtualenvs I have on my machine. 

One area that I think can be improved is where I build req_version_str via interpolation ([L307](https://github.com/naiquevin/pipdeptree/compare/master...t0m:master#diff-c9a0cc375d0f079d6251af1de64f535bR307)) so I can pass something like "pipdeptree>=0.1.2" into Requirement.parse. There must be a better way to get that string. Any suggestions?