### PR TITLE
show full dependency requirements

### DIFF
--- a/pipdeptree.py
+++ b/pipdeptree.py
@@ -211,12 +211,13 @@ def render_tree(tree, list_all=True, show_only=None, frozen=False):
     use_bullets = not frozen
 
     key_tree = dict((k.key, v) for k, v in tree.items())
-    get_children = lambda n: key_tree[n.key]
+
+    def get_children(n):
+        return key_tree[n.key]
 
     if show_only:
         nodes = [p for p in nodes
-                 if p.key in show_only
-                 or p.project_name in show_only]
+                 if p.key in show_only or p.project_name in show_only]
     elif not list_all:
         nodes = [p for p in nodes if p.key not in branch_keys]
 
@@ -282,8 +283,7 @@ def confusing_deps(tree):
         for r in rs:
             deps[r.key].append((p, r))
     return [ps for r, ps in deps.items()
-            if len(ps) > 1
-            and has_multi_versions(d for p, d in ps)]
+            if len(ps) > 1 and has_multi_versions(d for p, d in ps)]
 
 
 def cyclic_deps(tree):
@@ -298,7 +298,9 @@ def cyclic_deps(tree):
     """
     nodes = tree.keys()
     key_tree = dict((k.key, v) for k, v in tree.items())
-    get_children = lambda n: key_tree[n.key]
+
+    def get_children(n):
+        return key_tree[n.key]
 
     def aux(node, chain):
         if node.dist:
@@ -385,7 +387,8 @@ def main():
     if not args.nowarn:
         confusing = confusing_deps(tree)
         if confusing:
-            print('Warning!!! Possible confusing dependencies found:', file=sys.stderr)
+            print('Warning!!! Possible confusing dependencies found:',
+                  file=sys.stderr)
             for xs in confusing:
                 for i, (p, d) in enumerate(xs):
                     if d.key in skip:

--- a/pipdeptree.py
+++ b/pipdeptree.py
@@ -156,7 +156,7 @@ class ReqPackage(Package):
     @property
     def version_spec(self):
         specs = self._obj.specs
-        return ''.join(specs[0]) if specs else None
+        return ','.join([''.join(sp) for sp in specs]) if specs else None
 
     @property
     def installed_version(self):


### PR DESCRIPTION
I have noticed only the base dependency requirement is being currently shown, whereas the full dependency specs are needed for this tool to be useful. Please notice requirements of pbr and SQLAlchemy below:

cristian@cristian:~/projects/pipdeptree$ pipdeptree -w -p sqlalchemy-migrate
sqlalchemy-migrate==0.10.0
  - pbr [required: >=1.3,<2.0, installed: 1.8.1]
  - six [required: >=1.7.0, installed: 1.10.0]
  - SQLAlchemy [required: >=0.7.8,!=0.9.5, installed: 1.0.11]
  - sqlparse [installed: 0.1.18]
  - decorator [installed: 4.0.6]
  - Tempita [required: >=0.4, installed: 0.5.2]

(We should also check if these dependency requirements are being currently satisfied, or if they don't conflict with those of different packages, but this will be addressed by a separate commit.)

Some minor PEP8 violations have also been fixed.


