### PR TITLE
ENH: dump dependency graph as graphviz dot code

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -201,6 +201,14 @@ tools.
 
     $ python pipdeptree.py --json
 
+The dependency graph (acyclic if there are no circular dependencies)
+can be layed out as a PDF or image using GraphViz`GraphViz
+<http://www.graphviz.org/>`_ with:
+
+.. code-block:: bash
+
+    $ pipdeptree --dot | dot -Tpdf > dependencies.pdf
+
 
 Usage
 -----
@@ -233,6 +241,7 @@ Usage
        -j, --json            Display dependency tree as json. This will yield "raw"
                              output that may be used by external tools. This option
                              overrides all other options.
+       --dot                 Print the dependency graph as GraphViz dot code.
 
 
 Known Issues


### PR DESCRIPTION
An external call to [GraphViz `dot`](http://www.graphviz.org) is still needed, following the approach with `json`. This works even when `dot` is not installed.

An alternative would be to call the `pydot` graph method `write_pdf`, but then all layout options (including output file format) would have to be forwarded to it. Such a design would be nested, unlike the flat approach selected. It could still be added, as a `--pdf` option, or something similar.

This enhancement requires `networkx` and `pydot` (or `pydotplus`, for newer `networkx` versions).
Considering the graph layout option as optional, I did not modify the dependencies listed in `install_requires`. Both of the dependencies are pure Python, so adding them wouldn't make installation more difficult.
