### PR TITLE
Defer to pip's list of excluded default packages.

### DIFF
--- a/pipdeptree.py
+++ b/pipdeptree.py
@@ -415,10 +415,7 @@ def main():
                         ))
     args = parser.parse_args()
 
-    default_skip = ['setuptools', 'pip', 'python', 'distribute']
-    skip = default_skip + ['pipdeptree']
-    pkgs = pip.get_installed_distributions(local_only=args.local_only,
-                                           skip=skip)
+    pkgs = pip.get_installed_distributions(local_only=args.local_only)
 
     dist_index = build_dist_index(pkgs)
     tree = construct_tree(dist_index)

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open('./README.rst') as f:
     long_desc = f.read()
 
 
-install_requires = ["pip >= 1.4.1"]
+install_requires = ["pip >= 6.0.0"]
 if sys.version_info < (2, 7):
     install_requires.append('argparse')
     install_requires.append('ordereddict')


### PR DESCRIPTION
As of 6.0.0 pip will default to excluding the usual things we were
hardcoding here, so this just lets pip do its thing naturally.

This also removes 'pipdeptree' from the exclusion list, which seems
mandatory if your application actually *uses* pipdeptree and it's not
just for manual invocation (i.e.humans typing on keyboards)