### PR TITLE
Add different output options for dependency graph

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -201,6 +201,14 @@ tools.
 
     $ python pipdeptree.py --json
 
+The dependency graph (acyclic if there are no circular dependencies)
+can be layed out as a PDF or image using GraphViz`GraphViz
+<http://www.graphviz.org/>`_ with:
+
+.. code-block:: bash
+
+    $ pipdeptree --dot | dot -Tpdf > dependencies.pdf
+
 
 Usage
 -----
@@ -233,6 +241,7 @@ Usage
        -j, --json            Display dependency tree as json. This will yield "raw"
                              output that may be used by external tools. This option
                              overrides all other options.
+       --dot                 Print the dependency graph as GraphViz dot code.
 
 
 Known Issues

--- a/README.rst
+++ b/README.rst
@@ -243,7 +243,7 @@ Usage
        -j, --json            Display dependency tree as json. This will yield "raw"
                              output that may be used by external tools. This option
                              overrides all other options.
-       --output OUTPUT_FORMAT
+       --graph-output OUTPUT_FORMAT
                              Print a dependency graph in the specified output
                              format. Available are all formats supported by
                              GraphViz, e.g.: dot, jpeg, pdf, png, svg

--- a/README.rst
+++ b/README.rst
@@ -201,13 +201,15 @@ tools.
 
     $ python pipdeptree.py --json
 
-The dependency graph (acyclic if there are no circular dependencies)
-can be layed out as a PDF or image using GraphViz`GraphViz
-<http://www.graphviz.org/>`_ with:
+The dependency graph can be layed out as any of the formats supported by
+GraphViz`GraphViz<http://www.graphviz.org/>`_:
 
 .. code-block:: bash
 
-    $ pipdeptree --dot | dot -Tpdf > dependencies.pdf
+    $ pipdeptree --output dot > dependencies.dot
+    $ pipdeptree --output pdf > dependencies.pdf
+    $ pipdeptree --output png > dependencies.png
+    $ pipdeptree --output svg > dependencies.svg
 
 
 Usage
@@ -241,7 +243,10 @@ Usage
        -j, --json            Display dependency tree as json. This will yield "raw"
                              output that may be used by external tools. This option
                              overrides all other options.
-       --dot                 Print the dependency graph as GraphViz dot code.
+       --output OUTPUT_FORMAT
+                             Print a dependency graph in the specified output
+                             format. Available are all formats supported by
+                             GraphViz, e.g.: dot, jpeg, pdf, png, svg
 
 
 Known Issues

--- a/README.rst
+++ b/README.rst
@@ -206,10 +206,10 @@ GraphViz`GraphViz<http://www.graphviz.org/>`_:
 
 .. code-block:: bash
 
-    $ pipdeptree --output dot > dependencies.dot
-    $ pipdeptree --output pdf > dependencies.pdf
-    $ pipdeptree --output png > dependencies.png
-    $ pipdeptree --output svg > dependencies.svg
+    $ pipdeptree --graph-output dot > dependencies.dot
+    $ pipdeptree --graph-output pdf > dependencies.pdf
+    $ pipdeptree --graph-output png > dependencies.png
+    $ pipdeptree --graph-output svg > dependencies.svg
 
 
 Usage

--- a/pipdeptree.py
+++ b/pipdeptree.py
@@ -358,7 +358,7 @@ def dump_graphviz(tree, output_format='dot'):
         sys.exit(1)
 
     if output_format not in backend.FORMATS:
-        print('%s is no supported output format.' % output_format,
+        print('{} is no supported output format.'.format(output_format),
               file=sys.stderr)
         print('Supported formats are: %s' % ', '.join(sorted(backend.FORMATS)),
               file=sys.stderr)
@@ -466,7 +466,7 @@ def main():
                             '"raw" output that may be used by external tools. '
                             'This option overrides all other options.'
                         ))
-    parser.add_argument('--output', dest='output_format', required=False,
+    parser.add_argument('--graph-output', dest='output_format',
                         help=(
                             'Print a dependency graph in the specified output '
                             'format. Available are all formats supported by '

--- a/pipdeptree.py
+++ b/pipdeptree.py
@@ -360,14 +360,14 @@ def dump_graphviz(tree, output_format='dot'):
     if output_format not in backend.FORMATS:
         print('{} is no supported output format.'.format(output_format),
               file=sys.stderr)
-        print('Supported formats are: %s' % ', '.join(sorted(backend.FORMATS)),
-              file=sys.stderr)
+        print('Supported formats are: {}'.format(
+            ', '.join(sorted(backend.FORMATS))), file=sys.stderr)
         sys.exit(1)
 
     graph = Digraph(format=output_format)
     for package, deps in tree.items():
         project_name = package.project_name
-        label = '%s\n%s' % (project_name, package.version)
+        label = '{}\n{}'.format(project_name, package.version)
         graph.node(project_name, label=label)
         for dep in deps:
             label = dep.version_spec
@@ -497,10 +497,10 @@ def main():
                   file=sys.stderr)
             for p, reqs in conflicting.items():
                 pkg = p.render_as_root(False)
-                print('* %s' % pkg, file=sys.stderr)
+                print('* {}'.format(pkg), file=sys.stderr)
                 for req in reqs:
                     req_str = req.render_as_branch(False)
-                    print(' - %s' % req_str, file=sys.stderr)
+                    print(' - {}'.format(req_str), file=sys.stderr)
             print('-'*72, file=sys.stderr)
 
         cyclic = cyclic_deps(tree)

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
     description='Command line utility to show dependency tree of packages',
     long_description=long_desc,
     install_requires=install_requires,
+    extras_require={'graphviz': ['graphviz']},
     py_modules=['pipdeptree'],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Add the option to output a dependency graph in any output format
supported by GraphViz.

Based on the idea and code from @johnyf to output the dependency
graph as dot code: #43

Goes a step further than that, by using `graphviz` instead of
`networkx` and `pydotplus`, which allows output as dot code as well, but
enables output in any of GraphViz supported output formats directly,
if the GraphViz command line tools are installed.