### PR TITLE
Pre-filter Dependency Tree before Rendering

### DIFF
--- a/pipdeptree.py
+++ b/pipdeptree.py
@@ -132,7 +132,7 @@ def filter_tree(tree, list_all=True, show_only=None):
         node_keys = [node.key for node in nodes if node.key not in branch_keys]
 
     return dict([
-        (node, deps) for node, deps in tree.items() if node.key in nodes_keys])
+        (node, deps) for node, deps in tree.items() if node.key in node_keys])
 
 
 def guess_version(pkg_key, default='?'):

--- a/pipdeptree.py
+++ b/pipdeptree.py
@@ -131,8 +131,8 @@ def filter_tree(tree, list_all=True, show_only=None):
     elif not list_all:
         node_keys = [node.key for node in nodes if node.key not in branch_keys]
 
-    return {
-        node: deps for node, deps in tree.items() if node.key in nodes_keys}
+    return dict([
+        (node, deps) for node, deps in tree.items() if node.key in nodes_keys])
 
 
 def guess_version(pkg_key, default='?'):

--- a/tests/test_pipdeptree.py
+++ b/tests/test_pipdeptree.py
@@ -97,8 +97,8 @@ def test_ReqPackage_render_as_branch():
     assert mks2.render_as_branch(True) == 'MarkupSafe==0.18'
 
 
-def test_render_tree_only_top():
-    tree_str = render_tree(tree, list_all=False)
+def test_render_tree():
+    tree_str = render_tree(tree)
     lines = set(tree_str.split('\n'))
     assert 'Flask-Script==0.6.6' in lines
     assert '  - SQLAlchemy [required: >=0.7.3, installed: 0.9.1]' in lines
@@ -106,17 +106,8 @@ def test_render_tree_only_top():
     assert 'itsdangerous==0.23' not in lines
 
 
-def test_render_tree_list_all():
-    tree_str = render_tree(tree, list_all=True)
-    lines = set(tree_str.split('\n'))
-    assert 'Flask-Script==0.6.6' in lines
-    assert '  - SQLAlchemy [required: >=0.7.3, installed: 0.9.1]' in lines
-    assert 'Lookupy==0.1' in lines
-    assert 'itsdangerous==0.23' in lines
-
-
 def test_render_tree_freeze():
-    tree_str = render_tree(tree, list_all=False, frozen=True)
+    tree_str = render_tree(tree, frozen=True)
     lines = set()
     for line in tree_str.split('\n'):
         # Workaround for https://github.com/pypa/pip/issues/1867
@@ -144,7 +135,7 @@ def test_cyclic_dependencies():
 
 def test_render_tree_cyclic_dependency():
     cyclic_pkgs, dist_index, tree = venv_fixture('tests/virtualenvs/cyclicenv.pickle')
-    tree_str = render_tree(tree, list_all=True)
+    tree_str = render_tree(tree)
     lines = set(tree_str.split('\n'))
     assert 'CircularDependencyA==0.0.0' in lines
     assert '  - CircularDependencyB [required: Any, installed: 0.0.0]' in lines
@@ -154,7 +145,7 @@ def test_render_tree_cyclic_dependency():
 
 def test_render_tree_freeze_cyclic_dependency():
     cyclic_pkgs, dist_index, tree = venv_fixture('tests/virtualenvs/cyclicenv.pickle')
-    tree_str = render_tree(tree, list_all=True, frozen=True)
+    tree_str = render_tree(tree, frozen=True)
     lines = set(tree_str.split('\n'))
     assert 'CircularDependencyA==0.0.0' in lines
     assert '  CircularDependencyB==0.0.0' in lines

--- a/tests/test_pipdeptree.py
+++ b/tests/test_pipdeptree.py
@@ -98,8 +98,7 @@ def test_ReqPackage_render_as_branch():
 
 
 def test_render_tree_only_top():
-    tree = filter_tree(tree, list_all=False)
-    tree_str = render_tree(tree)
+    tree_str = render_tree(filter_tree(tree, list_all=False))
     lines = set(tree_str.split('\n'))
     assert 'Flask-Script==0.6.6' in lines
     assert '  - SQLAlchemy [required: >=0.7.3, installed: 0.9.1]' in lines
@@ -108,8 +107,7 @@ def test_render_tree_only_top():
 
 
 def test_render_tree_list_all():
-    tree = filter_tree(tree, list_all=True)
-    tree_str = render_tree(tree)
+    tree_str = render_tree(filter_tree(tree, list_all=True))
     lines = set(tree_str.split('\n'))
     assert 'Flask-Script==0.6.6' in lines
     assert '  - SQLAlchemy [required: >=0.7.3, installed: 0.9.1]' in lines
@@ -118,8 +116,7 @@ def test_render_tree_list_all():
 
 
 def test_render_tree_freeze():
-    tree = filter_tree(tree, list_all=False)
-    tree_str = render_tree(tree, frozen=True)
+    tree_str = render_tree(filter_tree(tree, list_all=False), frozen=True)
     lines = set()
     for line in tree_str.split('\n'):
         # Workaround for https://github.com/pypa/pip/issues/1867

--- a/tests/test_pipdeptree.py
+++ b/tests/test_pipdeptree.py
@@ -2,7 +2,7 @@ import pickle
 from operator import itemgetter, attrgetter
 
 from pipdeptree import (build_dist_index, construct_tree,
-                        DistPackage, ReqPackage, render_tree,
+                        DistPackage, ReqPackage, filter_tree, render_tree,
                         reverse_tree, cyclic_deps, conflicting_deps)
 
 
@@ -97,7 +97,8 @@ def test_ReqPackage_render_as_branch():
     assert mks2.render_as_branch(True) == 'MarkupSafe==0.18'
 
 
-def test_render_tree():
+def test_render_tree_only_top():
+    tree = filter_tree(tree, list_all=False)
     tree_str = render_tree(tree)
     lines = set(tree_str.split('\n'))
     assert 'Flask-Script==0.6.6' in lines
@@ -106,7 +107,18 @@ def test_render_tree():
     assert 'itsdangerous==0.23' not in lines
 
 
+def test_render_tree_list_all():
+    tree = filter_tree(tree, list_all=True)
+    tree_str = render_tree(tree)
+    lines = set(tree_str.split('\n'))
+    assert 'Flask-Script==0.6.6' in lines
+    assert '  - SQLAlchemy [required: >=0.7.3, installed: 0.9.1]' in lines
+    assert 'Lookupy==0.1' in lines
+    assert 'itsdangerous==0.23' in lines
+
+
 def test_render_tree_freeze():
+    tree = filter_tree(tree, list_all=False)
     tree_str = render_tree(tree, frozen=True)
     lines = set()
     for line in tree_str.split('\n'):


### PR DESCRIPTION
This PR always force pre-filtering of the dependency tree before any rendering of any sort occurs, thus allowing usage `--packages` and `--all` parameters for both JSON or Graphviz output.