### PR TITLE
console-script entry point for version-specific python

### DIFF
--- a/pipdeptree.py
+++ b/pipdeptree.py
@@ -368,7 +368,7 @@ def dump_graphviz(tree, output_format='dot'):
     graph = Digraph(format=output_format)
     for package, deps in tree.items():
         project_name = package.project_name
-        label = '{0}\n{1}'.format(project_name, package.version)
+        label = '{0} {1}'.format(project_name, package.version)
         graph.node(project_name, label=label)
         for dep in deps:
             label = dep.version_spec

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import re
+import sys
 import ast
 
 from setuptools import setup
@@ -33,7 +34,8 @@ setup(
     py_modules=['pipdeptree'],
     entry_points={
         'console_scripts': [
-            'pipdeptree = pipdeptree:main'
+            'pipdeptree = pipdeptree:main',
+            'pipdeptree{} = pipdeptree:main'.format(str(sys.version_info[0]))
         ]
     },
     classifiers=[


### PR DESCRIPTION
Add an entry to setup.py's entry points to create a second console-script paired to the major version of Python used to pip install. This lets us have pipdeptree console scripts installed for Python2 and Python3 for use in mixed environments.

Tested by locally installing editable via pip, and by running the tox test suite against both py27 and py36 virtual envs.