### PR TITLE
Update psycopg2 version in one of the test environments

### DIFF
--- a/tests/virtualenvs/testenv_requirements.txt
+++ b/tests/virtualenvs/testenv_requirements.txt
@@ -10,6 +10,6 @@ alembic==0.6.2
 gnureadline==6.3.3
 ipython==2.0.0
 itsdangerous==0.23
-psycopg2==2.5.2
+psycopg2==2.7.3.2
 redis==2.9.1
 slugify==0.0.1


### PR DESCRIPTION
psycopg 2.5.2 fails to install with PostgreSQL 10+.