### PR TITLE
Fix missing 'setuptools' requirement

### DIFF
--- a/pipdeptree.py
+++ b/pipdeptree.py
@@ -19,7 +19,7 @@ try:
 except ImportError:
     from pip import get_installed_distributions, FrozenRequirement
 
-import pkg_resources
+from pip._vendor import pkg_resources
 # inline:
 # from graphviz import backend, Digraph
 


### PR DESCRIPTION
The package 'pkg_resources' is part of the 'setuptools' project. The
project 'pip' (in its current version) vendors setuptools.

Since 'pipdeptree' currently uses pip's private internal API already,
we might as well use pip's vendored pkg_resources. This, of course,
might break if pip's internals change in a later version.

GitHub: naiquevin/pipdeptree#119