### PR TITLE
Avoid crashing when some dependencies aren't installed

### DIFF
--- a/pipdeptree.py
+++ b/pipdeptree.py
@@ -682,7 +682,7 @@ def cyclic_deps(tree):
     cyclic = []
     for p, rs in tree.items():
         for r in rs:
-            if p.key in index[r.key]:
+            if p.key in index.get(r.key, []):
                 p_as_dep_of_r = [x for x
                                  in tree.get(tree.get_node_as_parent(r.key))
                                  if x.key == p.key][0]

--- a/tests/test_pipdeptree.py
+++ b/tests/test_pipdeptree.py
@@ -457,6 +457,13 @@ def test_conflicting_deps(capsys, mpkgs, expected_keys, expected_output):
                 '* b => a => b',
                 '* a => b => a'
             ]
+        ),
+        ( # if a dependency isn't installed, cannot verify cycles
+            {
+                ('a', '1.0.1'): [('b', [('>=', '2.0.0')])],
+            },
+            [],
+            [] # no output expected
         )
     ]
 )


### PR DESCRIPTION
In general, folks should have all their dependencies installed for pipdeptree to evaluate everything. However, I was using it to figure out which packages were trying to install a package that was explicitly uninstallable on my platform. This meant that pip failed mid-install, so many remaining packages had not been installed.

This change avoids a crash in the case that a dependency is not installed.

To do: perhaps it should also emit a warning? I suppose silently skipping a check is not the best for users..