### PR TITLE
Allow querying non-host python intepreters

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -40,8 +40,9 @@ jobs:
     - uses: actions/checkout@v2
     - name: Pick tox environment to run
       run: |
-        import subprocess; import json
-        major, minor, impl = json.loads(subprocess.check_output(["python", "-c", "import json; import sys; import platform; print(json.dumps([sys.version_info[0], sys.version_info[1], platform.python_implementation()]));"], universal_newlines=True))
+        import platform
+        import sys
+        major, minor, impl = sys.version_info[0], sys.version_info[1], platform.python_implementation()
         print('::set-env name=TOXENV::' + ("py" if impl == "CPython" else "pypy") + ("{}{}".format(major, minor) if impl == "CPython" else ("3" if major == 3 else "")))
       shell: python
     - name: Setup test suite

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -25,16 +25,26 @@ jobs:
         - pypy3
         - pypy2
     steps:
+    - name: Setup graphviz
+      uses: ts-graphviz/setup-graphviz@v1
+    - name: Setup python for tox
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Install tox
+      run: python -m pip install tox
     - name: Setup python for test ${{ matrix.py }}
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.py }}
     - uses: actions/checkout@v2
-    - name: Setup graphviz
-      uses: ts-graphviz/setup-graphviz@v1
-    - name: Install dev requirements
-      run: pip install -r dev-requirements.txt
-    - name: Install project
-      run: pip install .[graphviz]
+    - name: Pick tox environment to run
+      run: |
+        import subprocess; import json
+        major, minor, impl = json.loads(subprocess.check_output(["python", "-c", "import json; import sys; import platform; print(json.dumps([sys.version_info[0], sys.version_info[1], platform.python_implementation()]));"], universal_newlines=True))
+        print('::set-env name=TOXENV::' + ("py" if impl == "CPython" else "pypy") + ("{}{}".format(major, minor) if impl == "CPython" else ("3" if major == 3 else "")))
+      shell: python
+    - name: Setup test suite
+      run: tox -vv --notest
     - name: Run test suite
-      run: pytest -v tests
+      run: tox --skip-pkg-install

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,8 +1,0 @@
-flake8
-graphviz
-pip>=8.0.2
-pytest
-pytest-cov
-tox>=3
-virtualenv>=20,<21
-mock;python_version<"3"

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,8 @@
+flake8
+graphviz
+pip>=8.0.2
 pytest
 pytest-cov
-jinja2
-ipython
-flake8
+tox>=3
+virtualenv>=20,<21
 mock;python_version<"3"

--- a/pipdeptree.py
+++ b/pipdeptree.py
@@ -791,9 +791,12 @@ def handle_non_host_target(args):
                   " non-host python", file=sys.stderr)
             raise SystemExit(1)
         argv = sys.argv[1:]  # remove current python executable
-        py_at = argv.index('--python')  # plus the new python target
-        del argv[py_at]
-        del argv[py_at]
+        for py_at, value in enumerate(argv):
+            if value == "--python":
+                del argv[py_at]
+                del argv[py_at]
+            elif value.startswith("--python"):
+                del argv[py_at]
         # feed the file as argument, instead of file
         # to avoid adding the file path to sys.path, that can affect result
         file_path = inspect.getsourcefile(sys.modules[__name__])

--- a/tests/test_pipdeptree.py
+++ b/tests/test_pipdeptree.py
@@ -523,9 +523,11 @@ def test_parser_svg():
     assert not args.json
 
 
-def test_custom_interpreter(tmp_path, monkeypatch, capfd):
+@pytest.mark.parametrize('args_joined', [True, False])
+def test_custom_interpreter(tmp_path, monkeypatch, capfd, args_joined):
     result = virtualenv.cli_run([str(tmp_path), '--activators', ''])
-    cmd = [sys.executable, '--python', str(result.creator.exe)]
+    cmd = [sys.executable]
+    cmd += ['--python={}'.format(result.creator.exe)] if args_joined else ['--python', str(result.creator.exe)]
     monkeypatch.setattr(sys, 'argv', cmd)
     p.main()
     out, _ = capfd.readouterr()

--- a/tox.ini
+++ b/tox.ini
@@ -1,18 +1,24 @@
-# Tox (http://tox.testrun.org/) is a tool for running tests
-# in multiple virtualenvs. This configuration file will run the
-# test suite on all supported python versions. To use it, "pip install tox"
-# and then run "tox" from this directory.
-
+# http://tox.readthedocs.org/ - sets up and runs the test suite based on a declarative configuration
 [tox]
-envlist = py27, py34, py35, py36, py37, py38
+envlist =
+  py39
+  py38
+  py37
+  py36
+  py35
+  py34
+  py27
+  pypy3
+  pypy2
 
 [testenv]
+description = run test suite under {basepython}
 commands =
-    pytest {posargs:-vv}
+  pytest {posargs:-vv}
 deps =
-    tox>=3.0.0
-    graphviz
-    pip>=8.0.2
-    pytest
-    pytest-cov
-    virtualenv>=20
+  graphviz
+  pip>=8.0.2
+  pytest
+  pytest-cov
+  virtualenv>=20,<21
+  mock;python_version<"3"

--- a/tox.ini
+++ b/tox.ini
@@ -22,3 +22,5 @@ deps =
   pytest-cov
   virtualenv>=20,<21
   mock;python_version<"3"
+extras =
+  graphviz

--- a/tox.ini
+++ b/tox.ini
@@ -15,3 +15,4 @@ deps =
     pip>=8.0.2
     pytest
     pytest-cov
+    virtualenv>=20


### PR DESCRIPTION
This way you can install once (for example via pipx) and reuse it for any existing python environment.

```bash

$ pipdeptree --python venv/bin/python
pip==20.1.1
setuptools==49.2.0
wheel==0.34.2

```

@naiquevin for your attention. The CI fails because I cannot add the virtualenv dependency to Travis, it will only take effect post merge.