### PR TITLE
Shield newline symbol when generating labels for graphviz

### DIFF
--- a/pipdeptree.py
+++ b/pipdeptree.py
@@ -594,19 +594,19 @@ def dump_graphviz(tree, output_format='dot', is_reverse=False):
 
     if not is_reverse:
         for pkg, deps in tree.items():
-            pkg_label = '{0}\n{1}'.format(pkg.project_name, pkg.version)
+            pkg_label = '{0}\\n{1}'.format(pkg.project_name, pkg.version)
             graph.node(pkg.key, label=pkg_label)
             for dep in deps:
                 edge_label = dep.version_spec or 'any'
                 if dep.is_missing:
-                    dep_label = '{0}\n(missing)'.format(dep.project_name)
+                    dep_label = '{0}\\n(missing)'.format(dep.project_name)
                     graph.node(dep.key, label=dep_label, style='dashed')
                     graph.edge(pkg.key, dep.key, style='dashed')
                 else:
                     graph.edge(pkg.key, dep.key, label=edge_label)
     else:
         for dep, parents in tree.items():
-            dep_label = '{0}\n{1}'.format(dep.project_name,
+            dep_label = '{0}\\n{1}'.format(dep.project_name,
                                           dep.installed_version)
             graph.node(dep.key, label=dep_label)
             for parent in parents:


### PR DESCRIPTION
Python converts '\n' to actual newline before putting it into dot format. Although the previous approach somehow works it's better to pass '\n' explicitly.

Generated code before:
```
digraph {
	plotly [label="plotly
4.5.4"]
	plotly -> six [label=any]
	plotly -> retrying [label=">=1.3.3"]
	retrying [label="retrying
1.3.3"]
	retrying -> six [label=">=1.7.0"]
	six [label="six
1.12.0"]
}
```

Generated code after:
```
digraph {
	plotly [label="plotly\n4.5.4"]
	plotly -> six [label=any]
	plotly -> retrying [label=">=1.3.3"]
	retrying [label="retrying\n1.3.3"]
	retrying -> six [label=">=1.7.0"]
	six [label="six\n1.12.0"]
}
``` 