### PR TITLE
Fix GitHub Actions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,22 +8,24 @@ on:
 jobs:
   test:
     name: Test on ${{ matrix.py }} under ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os:
-        - Ubuntu
+        - Ubuntu-latest
         py:
         - 3.9-dev
         - 3.8
         - 3.7
         - 3.6
         - 3.5
-        - 3.4
         - 2.7
         - pypy3
         - pypy2
+        include:
+          - os: Ubuntu-18.04
+            py: 3.4
     steps:
     - name: Setup graphviz
       uses: ts-graphviz/setup-graphviz@v1

--- a/pipdeptree.py
+++ b/pipdeptree.py
@@ -119,6 +119,9 @@ class Package(object):
     def __repr__(self):
         return '<{0}("{1}")>'.format(self.__class__.__name__, self.key)
 
+    def __lt__(self, rhs):
+        return self.key < rhs.key
+
 
 class DistPackage(Package):
     """Wrapper class for pkg_resources.Distribution instances

--- a/pipdeptree.py
+++ b/pipdeptree.py
@@ -524,6 +524,7 @@ def render_json(tree, indent):
     :rtype: str
 
     """
+    tree = tree.sort()
     return json.dumps([{'package': k.as_dict(),
                         'dependencies': [v.as_dict() for v in vs]}
                        for k, vs in tree.items()],

--- a/pipdeptree.py
+++ b/pipdeptree.py
@@ -6,7 +6,6 @@ import subprocess
 from itertools import chain
 from collections import defaultdict, deque
 import argparse
-from operator import attrgetter
 import json
 from importlib import import_module
 import tempfile
@@ -50,9 +49,7 @@ def sorted_tree(tree):
     :rtype: collections.OrderedDict
 
     """
-    return OrderedDict(sorted([(k, sorted(v, key=attrgetter('key')))
-                               for k, v in tree.items()],
-                              key=lambda kv: kv[0].key))
+    return OrderedDict([(k, sorted(v)) for k, v in sorted(tree.items())])
 
 
 def guess_version(pkg_key, default='?'):
@@ -671,7 +668,7 @@ def render_conflicts_text(conflicts):
         print('Warning!!! Possibly conflicting dependencies found:',
               file=sys.stderr)
         # Enforce alphabetical order when listing conflicts
-        pkgs = sorted(conflicts.keys(), key=attrgetter('key'))
+        pkgs = sorted(conflicts.keys())
         for p in pkgs:
             pkg = p.render_as_root(False)
             print('* {}'.format(pkg), file=sys.stderr)


### PR DESCRIPTION
GitHub upgraded it's `ubuntu-latest` to 20.04, which deprecated python3.4, this patch re-enables python3.4 on ubuntu18.04.

In addition, I slightly refactor the code by adding `Package.__lt__`.
As a result, package sorting can be simplified.