### PR TITLE
License file to be included into metadata dir

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
     author_email='naikvin@gmail.com',
     url='https://github.com/naiquevin/pipdeptree',
     license='MIT License',
+    license_file='LICENSE',
     description='Command line utility to show dependency tree of packages',
     long_description=long_desc,
     install_requires=install_requires,


### PR DESCRIPTION
Hi,
Please, add the LICENSE file into metadata dir of your package (e.g. by accepting this pull request).
I understand you probably hate software laws etc., so I will be short.

You are using MIT license. It says also: "The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software." But your whole package distributed on PyPI.org does not contain even one. This short change will add the file LICENSE (with text of MIT license) into metadata of your package (= into e.g. .../site-packages/pipdeptree-2.0.0.dist-info/LICENSE of your virtualenv). This way you are 100% clear and comply with your chosen license.

Thank you for your time.
Pax et bonum.