### PR TITLE
Fix "AttributeError: module 'graphviz.backend' has no attribute 'FORMATS'"

### DIFF
--- a/pipdeptree.py
+++ b/pipdeptree.py
@@ -592,17 +592,17 @@ def dump_graphviz(tree, output_format='dot', is_reverse=False):
 
     """
     try:
-        from graphviz import backend, Digraph
+        from graphviz import parameters, Digraph
     except ImportError:
         print('graphviz is not available, but necessary for the output '
               'option. Please install it.', file=sys.stderr)
         sys.exit(1)
 
-    if output_format not in backend.FORMATS:
+    if output_format not in parameters.FORMATS:
         print('{0} is not a supported output format.'.format(output_format),
               file=sys.stderr)
         print('Supported formats are: {0}'.format(
-            ', '.join(sorted(backend.FORMATS))), file=sys.stderr)
+            ', '.join(sorted(parameters.FORMATS))), file=sys.stderr)
         sys.exit(1)
 
     graph = Digraph(format=output_format)


### PR DESCRIPTION
This PR fix the following error:

```
PS D:\Users\Rodrigo\GitHub\deepshift> pipdeptree --graph-output svg > dependencies.svg
Traceback (most recent call last):
  File "C:\Python39\Scripts\pipdeptree-script.py", line 33, in <module>
    sys.exit(load_entry_point('pipdeptree', 'console_scripts', 'pipdeptree')())
  File "d:\users\rodrigo\github\pipdeptree\pipdeptree.py", line 877, in main
    output = dump_graphviz(tree,
  File "d:\users\rodrigo\github\pipdeptree\pipdeptree.py", line 601, in dump_graphviz
    if output_format not in backend.FORMATS:
AttributeError: module 'graphviz.backend' has no attribute 'FORMATS'
```
